### PR TITLE
HD VIN: Capitalize VINS in the check function

### DIFF
--- a/src/content/projects/hd-vin-decoder/hd-vin-decoder.js
+++ b/src/content/projects/hd-vin-decoder/hd-vin-decoder.js
@@ -97,6 +97,9 @@ function decodeVIN( vin, div ){
 }
 
 function verifyCheckDigit( vin ){
+	
+	// setup
+	vin = vin.toUpperCase();
 
 	letterValues = {
 			  A: 1, B: 2, C: 3, D: 4, E: 5, F: 6, G: 7, H: 8,


### PR DESCRIPTION
Re: Issue #310

Note that line 5 in the hd-vin-decoder.js file is now redundant. 

Test performed in console:
<img width="279" alt="#310 test" src="https://user-images.githubusercontent.com/18604081/82282022-d81e5c80-9960-11ea-849f-2c2acd6c63df.png">
